### PR TITLE
feat: change tracking and revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This plugin provides a bridge between neovim and the [goose](https://github.com/
 ## 📑 Table of Contents
 
 - [Requirements](#-requirements)
-- [Compatibility](#-compatibility)
 - [Installation](#-installation)
 - [Configuration](#️-configuration)
 - [Usage](#-usage)
@@ -31,11 +30,6 @@ This plugin provides a bridge between neovim and the [goose](https://github.com/
 ## 📋 Requirements
 
 - Goose CLI installed and available (see [Setting up goose](#-setting-up-goose-cli) below)
-
-## ⚡ Compatibility
-
-This plugin is compatible with Goose CLI version **`1.0.18`**. 
-Other versions may work but are not guaranteed. If you encounter issues with newer Goose CLI versions, please report them in the issues section.
 
 ## 🚀 Installation
 
@@ -77,6 +71,9 @@ require('goose').setup({
       close = '<leader>gq',                  -- Close UI windows
       toggle_fullscreen = '<leader>gf',      -- Toggle between normal and fullscreen mode
       select_session = '<leader>gs',         -- Select and load a goose session
+      diff_changes = '<leader>gd',           -- Display a vertical split diff of changes since the last goose prompt
+      revert_all = '<leader>gra',            -- Revert all file changes since the last goose prompt
+      revert_this = '<leader>grt',           -- Revert current file changes since the last goose prompt
     },
     window = {
       submit = '<cr>',                     -- Submit prompt
@@ -121,6 +118,9 @@ The plugin provides the following actions that can be triggered via keymaps, com
 | Navigate to next message | `]]` | - | - |
 | Navigate to previous message | `[[` | - | - |
 | Toggle input/output panes | `<tab>` | - | - |
+| Display diff of changes since last prompt | `<leader>gd` | `:GooseDiff` | `require('goose.api').diff()` |
+| Revert all file changes since last prompt | `<leader>gra` | `:GooseRevertAll` | `require('goose.api').revert_all()` |
+| Revert current file changes since last prompt | `<leader>grt` | `:GooseRevertThis` | `require('goose.api').revert_this()` |
 
 ## 📝 Context
 

--- a/lua/goose/api.lua
+++ b/lua/goose/api.lua
@@ -1,6 +1,7 @@
 local core = require("goose.core")
 local ui = require("goose.ui.ui")
 local state = require("goose.state")
+local review = require("goose.review")
 
 local M = {}
 
@@ -81,6 +82,22 @@ function M.toggle_pane()
   end
 
   ui.toggle_pane()
+end
+
+function M.diff()
+  review.review()
+end
+
+function M.set_review_breakpoint()
+  review.set_breakpoint()
+end
+
+function M.revert_all()
+  review.revert_all()
+end
+
+function M.revert_this()
+  review.revert_current()
 end
 
 -- Command definitions that call the API functions
@@ -178,6 +195,38 @@ M.commands = {
     desc = "Run goose with a prompt (new session)",
     fn = function(opts)
       M.run_new_session(opts.args)
+    end
+  },
+
+  diff = {
+    name = "GooseDiff",
+    desc = "Display a vertical split diff of the changes since the last goose prompt",
+    fn = function()
+      M.diff()
+    end
+  },
+
+  set_review_breakpoint = {
+    name = "GooseSetReviewBreakpoint",
+    desc = "Set a review breakpoint to track changes",
+    fn = function()
+      M.set_review_breakpoint()
+    end
+  },
+
+  revert_all = {
+    name = "GooseRevertAll",
+    desc = "Revert all file changes since the last goose prompt",
+    fn = function()
+      M.revert_all()
+    end
+  },
+
+  revert_this = {
+    name = "GooseRevertThis",
+    desc = "Revert current file changes since the last goose prompt",
+    fn = function()
+      M.revert_this()
     end
   }
 }

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -1,5 +1,6 @@
 -- Default and user-provided settings for goose.nvim
 
+
 local M = {}
 
 -- Default configuration
@@ -14,6 +15,9 @@ M.defaults = {
       close = '<leader>gq',
       toggle_fullscreen = '<leader>gf',
       select_session = '<leader>gs',
+      diff_changes = '<leader>gd',
+      revert_all = '<leader>gra',
+      revert_this = '<leader>grt'
     },
     window = {
       submit = '<cr>',

--- a/lua/goose/core.lua
+++ b/lua/goose/core.lua
@@ -100,6 +100,7 @@ function M.run(prompt, opts)
 end
 
 function M.after_send()
+  require('goose.review').set_breakpoint()
   context.unload_attachments()
   state.last_sent_context = vim.deepcopy(context.context)
 

--- a/lua/goose/keymap.lua
+++ b/lua/goose/keymap.lua
@@ -37,6 +37,18 @@ function M.setup(keymap)
   vim.keymap.set({ 'n', 'v' }, global.toggle_focus, function()
     api.toggle_focus()
   end, { silent = false, desc = cmds.toggle_focus.desc })
+
+  vim.keymap.set({ 'n', 'v' }, global.diff_changes, function()
+    api.diff()
+  end, { silent = false, desc = cmds.diff.desc })
+
+  vim.keymap.set({ 'n', 'v' }, global.revert_all, function()
+    api.revert_all()
+  end, { silent = false, desc = cmds.revert_all.desc })
+
+  vim.keymap.set({ 'n', 'v' }, global.revert_this, function()
+    api.revert_this()
+  end, { silent = false, desc = cmds.revert_this.desc })
 end
 
 return M

--- a/lua/goose/review.lua
+++ b/lua/goose/review.lua
@@ -1,0 +1,267 @@
+local Path = require('plenary.path')
+local M = {}
+
+local function is_git_project()
+  -- Cache result
+  if M.__is_git_project ~= nil then
+    return M.__is_git_project
+  end
+
+  -- Check for .git directory in the current working directory
+  local git_dir = Path:new(vim.fn.getcwd()):joinpath('.git')
+  M.__is_git_project = git_dir:exists() and git_dir:is_dir()
+  return M.__is_git_project
+end
+
+local function get_snapshot_dir()
+  local cwd = vim.fn.getcwd()
+  local cwd_hash = vim.fn.sha256(cwd)
+  return Path:new(vim.fn.stdpath('data')):joinpath('goose', 'snapshot', cwd_hash)
+end
+
+local function get_git_files()
+  local handle = io.popen('git ls-files -m -o --exclude-standard')
+  local result = handle:read('*a')
+  handle:close()
+  return result
+end
+
+local function show_diff(file_path, snapshot_path)
+  local file_path_str = tostring(file_path)
+  local snapshot_path_str = snapshot_path and tostring(snapshot_path) or nil
+
+  if snapshot_path_str then
+    -- Compare with snapshot file
+    vim.cmd('edit ' .. snapshot_path_str)
+    vim.cmd('setlocal readonly buftype=nofile nomodifiable')
+    vim.cmd('diffthis')
+    local temp_buf = vim.api.nvim_get_current_buf()
+    local temp_win = vim.api.nvim_get_current_win()
+
+    vim.cmd('vsplit ' .. file_path_str)
+    vim.cmd('diffthis')
+
+    vim.api.nvim_create_autocmd("WinClosed", {
+      pattern = tostring(temp_win),
+      callback = function()
+        if vim.api.nvim_buf_is_valid(temp_buf) then
+          vim.api.nvim_buf_delete(temp_buf, { force = true })
+        end
+      end,
+      once = true
+    })
+  else
+    -- Compare with git HEAD
+    vim.cmd('edit ' .. file_path_str)
+
+    local temp_file = Path:new(vim.fn.tempname())
+    local git_cmd = 'git show HEAD:"' .. file_path_str .. '" > ' .. tostring(temp_file) .. ' 2>/dev/null'
+    vim.fn.system(git_cmd)
+
+    if vim.v.shell_error == 0 then
+      -- Get filetype from the original file
+      local file_type = vim.bo.filetype
+      vim.cmd('leftabove vsplit ' .. tostring(temp_file))
+      vim.cmd('setlocal readonly buftype=nofile nomodifiable filetype=' .. file_type)
+
+      local temp_buf = vim.api.nvim_get_current_buf()
+      local temp_win = vim.api.nvim_get_current_win()
+      vim.cmd('diffthis')
+      vim.cmd('wincmd l')
+      vim.cmd('diffthis')
+
+      vim.api.nvim_create_autocmd("WinClosed", {
+        pattern = tostring(temp_win),
+        callback = function()
+          vim.schedule(function()
+            -- Delete the temporary file if it exists
+            if temp_file:exists() then temp_file:rm() end
+
+            -- Delete buffer
+            if vim.api.nvim_buf_is_valid(temp_buf) then
+              vim.api.nvim_buf_delete(temp_buf, { force = true })
+            end
+          end)
+        end,
+        once = true
+      })
+    else
+    end
+  end
+end
+
+local function get_changed_files()
+  local files = {}
+  local git_files = get_git_files()
+  local snapshot_base = get_snapshot_dir()
+
+  for file in git_files:gmatch("[^\n]+") do
+    local snapshot_file = snapshot_base:joinpath(file)
+
+    if snapshot_file:exists() then
+      local cmp_handle = io.popen('cmp -s "' .. file .. '" "' .. tostring(snapshot_file) .. '"; echo $?')
+      local cmp_result = cmp_handle:read('*n')
+      cmp_handle:close()
+
+      if cmp_result ~= 0 then table.insert(files, { file, snapshot_file }) end
+    else
+      table.insert(files, { file, nil })
+    end
+  end
+
+  return files
+end
+
+local function revert_file(file_path, snapshot_path)
+  -- First try to revert from snapshot if available
+  if snapshot_path then
+    local success = Path:new(snapshot_path):copy({ destination = file_path, override = true })
+    if success then return true end
+  else
+    -- Try to revert from git if it's a tracked file
+    local is_in_git = os.execute('git ls-files --error-unmatch "' .. file_path .. '" > /dev/null 2>&1') == 0
+
+    if is_in_git then
+      local temp_file = Path:new(vim.fn.tempname())
+      if os.execute('git show HEAD:"' .. file_path .. '" > ' .. tostring(temp_file) .. ' 2>/dev/null') == 0 then
+        temp_file:copy { destination = file_path, override = true }
+        temp_file:rm()
+        return true
+      end
+      -- For untracked files, just remove them
+    elseif Path:new(file_path):rm() then
+      return true
+    end
+  end
+
+  vim.notify("Failed to revert '" .. file_path .. "'.")
+  return false
+end
+
+M.review = function()
+  if not is_git_project() then
+    vim.notify("Error: Not in a git project.")
+    return
+  end
+
+  local files = get_changed_files()
+
+  if #files == 0 then
+    vim.notify("No changes to review.")
+    return
+  end
+
+  if #files == 1 then
+    show_diff(files[1][1], files[1][2])
+  else
+    vim.ui.select(vim.tbl_map(function(f) return f[1] end, files),
+      { prompt = "Select a file to review:" },
+      function(choice, idx)
+        if not choice then return end
+        show_diff(files[idx][1], files[idx][2])
+      end)
+  end
+end
+
+M.set_breakpoint = function()
+  if not is_git_project() then
+    return
+  end
+
+  local snapshot_base = get_snapshot_dir()
+
+  -- Remove existing snapshot directory if it exists
+  if snapshot_base:exists() then
+    snapshot_base:rm({ recursive = true })
+  end
+
+  -- Create snapshot directory
+  snapshot_base:mkdir({ parents = true })
+
+  for file in get_git_files():gmatch("[^\n]+") do
+    local source_file = Path:new(file)
+    local target_file = snapshot_base:joinpath(file)
+
+    -- Create parent directories for the target file
+    target_file:parent():mkdir({ parents = true })
+
+    -- Copy the file
+    source_file:copy { destination = target_file }
+  end
+end
+
+M.revert_all = function()
+  if not is_git_project() then
+    vim.notify("Error: Not in a git project.")
+    return
+  end
+
+  local files = get_changed_files()
+
+  if #files == 0 then
+    vim.notify("No changes to revert.")
+    return
+  end
+
+  if vim.fn.input("Revert all " .. #files .. " changed files? (y/n): "):lower() ~= "y" then
+    return
+  end
+
+  local success_count = 0
+  for _, file_data in ipairs(files) do
+    if revert_file(file_data[1], file_data[2]) then
+      success_count = success_count + 1
+    end
+  end
+
+  -- reload modified files
+  vim.cmd('checktime')
+  vim.notify("Reverted " .. success_count .. " of " .. #files .. " files.")
+end
+
+M.revert_current = function()
+  if not is_git_project() then
+    vim.notify("Error: Not in a git project.")
+    return
+  end
+
+  local current_file = vim.fn.expand('%:p')
+  local cwd = vim.fn.getcwd()
+  local rel_path = string.sub(current_file, string.len(cwd) + 2) -- +2 for trailing slash
+  local snapshot_path = get_snapshot_dir():joinpath(rel_path)
+
+  -- Check if the file has changes
+  local has_changes = os.execute('git diff --quiet --exit-code "' .. rel_path .. '" > /dev/null 2>&1') ~= 0 or
+      os.execute('git ls-files --others --exclude-standard | grep -q "^' ..
+        vim.fn.escape(rel_path, '.') .. '$" > /dev/null 2>&1') == 0
+
+  if not has_changes then
+    vim.notify("No changes to revert.")
+    return
+  end
+
+  vim.cmd('update') -- Save the current buffer
+
+  if vim.fn.input("Revert current file? (y/n): "):lower() ~= "y" then
+    return
+  end
+
+  local has_snapshot = snapshot_path:exists()
+
+  if revert_file(rel_path, has_snapshot and tostring(snapshot_path) or nil) then
+    local file = Path:new(rel_path)
+    if file:exists() then
+      vim.cmd('e!')       -- Reload the buffer if file still exists
+    else
+      vim.cmd('bdelete!') -- Close the buffer if file was deleted
+    end
+  end
+end
+
+-- Function to reset the git project status cache
+-- Should be called if the working directory changes
+M.reset_git_status = function()
+  M.__is_git_project = nil
+end
+
+return M

--- a/lua/goose/review.lua
+++ b/lua/goose/review.lua
@@ -1,29 +1,52 @@
 local Path = require('plenary.path')
 local M = {}
 
-local function is_git_project()
-  -- Cache result
-  if M.__is_git_project ~= nil then
+-- Git helpers
+local git = {
+  is_project = function()
+    -- Cache result
+    if M.__is_git_project ~= nil then
+      return M.__is_git_project
+    end
+    local git_dir = Path:new(vim.fn.getcwd()):joinpath('.git')
+    M.__is_git_project = git_dir:exists() and git_dir:is_dir()
     return M.__is_git_project
-  end
+  end,
 
-  -- Check for .git directory in the current working directory
-  local git_dir = Path:new(vim.fn.getcwd()):joinpath('.git')
-  M.__is_git_project = git_dir:exists() and git_dir:is_dir()
-  return M.__is_git_project
+  list_changed_files = function()
+    local handle = io.popen('git ls-files -m -o --exclude-standard')
+    local result = handle:read('*a')
+    handle:close()
+    return result
+  end,
+
+  is_tracked = function(file_path)
+    return os.execute('git ls-files --error-unmatch "' .. file_path .. '" > /dev/null 2>&1') == 0
+  end,
+
+  get_head_content = function(file_path, output_path)
+    return os.execute('git show HEAD:"' .. file_path .. '" > ' .. output_path .. ' 2>/dev/null') == 0
+  end
+}
+
+-- Decorator for git project checks
+local function require_git_project(fn, silent)
+  return function(...)
+    if not git.is_project() then
+      if not silent then
+        vim.notify("Error: Not in a git project.")
+      end
+      return
+    end
+    return fn(...)
+  end
 end
 
+-- File helpers
 local function get_snapshot_dir()
   local cwd = vim.fn.getcwd()
   local cwd_hash = vim.fn.sha256(cwd)
   return Path:new(vim.fn.stdpath('data')):joinpath('goose', 'snapshot', cwd_hash)
-end
-
-local function get_git_files()
-  local handle = io.popen('git ls-files -m -o --exclude-standard')
-  local result = handle:read('*a')
-  handle:close()
-  return result
 end
 
 local function show_diff(file_path, snapshot_path)
@@ -51,15 +74,10 @@ local function show_diff(file_path, snapshot_path)
       once = true
     })
   else
-    -- Compare with git HEAD
-    vim.cmd('edit ' .. file_path_str)
-
+    -- If file is tracked by git, compare with HEAD, otherwise just open it
     local temp_file = Path:new(vim.fn.tempname())
-    local git_cmd = 'git show HEAD:"' .. file_path_str .. '" > ' .. tostring(temp_file) .. ' 2>/dev/null'
-    vim.fn.system(git_cmd)
-
-    if vim.v.shell_error == 0 then
-      -- Get filetype from the original file
+    if git.get_head_content(file_path_str, tostring(temp_file)) then
+      vim.cmd('edit ' .. file_path_str)
       local file_type = vim.bo.filetype
       vim.cmd('leftabove vsplit ' .. tostring(temp_file))
       vim.cmd('setlocal readonly buftype=nofile nomodifiable filetype=' .. file_type)
@@ -74,10 +92,7 @@ local function show_diff(file_path, snapshot_path)
         pattern = tostring(temp_win),
         callback = function()
           vim.schedule(function()
-            -- Delete the temporary file if it exists
             if temp_file:exists() then temp_file:rm() end
-
-            -- Delete buffer
             if vim.api.nvim_buf_is_valid(temp_buf) then
               vim.api.nvim_buf_delete(temp_buf, { force = true })
             end
@@ -86,13 +101,15 @@ local function show_diff(file_path, snapshot_path)
         once = true
       })
     else
+      -- File is not tracked by git, just open it normally
+      vim.cmd('edit ' .. file_path_str)
     end
   end
 end
 
 local function get_changed_files()
   local files = {}
-  local git_files = get_git_files()
+  local git_files = git.list_changed_files()
   local snapshot_base = get_snapshot_dir()
 
   for file in git_files:gmatch("[^\n]+") do
@@ -113,37 +130,22 @@ local function get_changed_files()
 end
 
 local function revert_file(file_path, snapshot_path)
-  -- First try to revert from snapshot if available
-  if snapshot_path then
-    local success = Path:new(snapshot_path):copy({ destination = file_path, override = true })
-    if success then return true end
-  else
-    -- Try to revert from git if it's a tracked file
-    local is_in_git = os.execute('git ls-files --error-unmatch "' .. file_path .. '" > /dev/null 2>&1') == 0
-
-    if is_in_git then
-      local temp_file = Path:new(vim.fn.tempname())
-      if os.execute('git show HEAD:"' .. file_path .. '" > ' .. tostring(temp_file) .. ' 2>/dev/null') == 0 then
-        temp_file:copy { destination = file_path, override = true }
-        temp_file:rm()
-        return true
-      end
-      -- For untracked files, just remove them
-    elseif Path:new(file_path):rm() then
+  if snapshot_path and Path:new(snapshot_path):copy({ destination = file_path, override = true }) then
+    return true
+  elseif git.is_tracked(file_path) then
+    local temp_file = Path:new(vim.fn.tempname())
+    if git.get_head_content(file_path, tostring(temp_file)) then
+      temp_file:copy { destination = file_path, override = true }
+      temp_file:rm()
       return true
     end
   end
 
-  vim.notify("Failed to revert '" .. file_path .. "'.")
+  vim.notify("Failed to revert '" .. file_path .. "' - the file is untracked by git.")
   return false
 end
 
-M.review = function()
-  if not is_git_project() then
-    vim.notify("Error: Not in a git project.")
-    return
-  end
-
+M.review = require_git_project(function()
   local files = get_changed_files()
 
   if #files == 0 then
@@ -161,41 +163,26 @@ M.review = function()
         show_diff(files[idx][1], files[idx][2])
       end)
   end
-end
+end)
 
-M.set_breakpoint = function()
-  if not is_git_project() then
-    return
-  end
-
+M.set_breakpoint = require_git_project(function()
   local snapshot_base = get_snapshot_dir()
 
-  -- Remove existing snapshot directory if it exists
   if snapshot_base:exists() then
     snapshot_base:rm({ recursive = true })
   end
 
-  -- Create snapshot directory
   snapshot_base:mkdir({ parents = true })
 
-  for file in get_git_files():gmatch("[^\n]+") do
+  for file in git.list_changed_files():gmatch("[^\n]+") do
     local source_file = Path:new(file)
     local target_file = snapshot_base:joinpath(file)
-
-    -- Create parent directories for the target file
     target_file:parent():mkdir({ parents = true })
-
-    -- Copy the file
     source_file:copy { destination = target_file }
   end
-end
+end, true)
 
-M.revert_all = function()
-  if not is_git_project() then
-    vim.notify("Error: Not in a git project.")
-    return
-  end
-
+M.revert_all = require_git_project(function()
   local files = get_changed_files()
 
   if #files == 0 then
@@ -214,23 +201,15 @@ M.revert_all = function()
     end
   end
 
-  -- reload modified files
   vim.cmd('checktime')
   vim.notify("Reverted " .. success_count .. " of " .. #files .. " files.")
-end
+end)
 
-M.revert_current = function()
-  if not is_git_project() then
-    vim.notify("Error: Not in a git project.")
-    return
-  end
-
+M.revert_current = require_git_project(function()
   local current_file = vim.fn.expand('%:p')
-  local cwd = vim.fn.getcwd()
-  local rel_path = string.sub(current_file, string.len(cwd) + 2) -- +2 for trailing slash
+  local rel_path = vim.fn.fnamemodify(current_file, ':.')
   local snapshot_path = get_snapshot_dir():joinpath(rel_path)
 
-  -- Check if the file has changes
   local has_changes = os.execute('git diff --quiet --exit-code "' .. rel_path .. '" > /dev/null 2>&1') ~= 0 or
       os.execute('git ls-files --others --exclude-standard | grep -q "^' ..
         vim.fn.escape(rel_path, '.') .. '$" > /dev/null 2>&1') == 0
@@ -240,7 +219,7 @@ M.revert_current = function()
     return
   end
 
-  vim.cmd('update') -- Save the current buffer
+  vim.cmd('update')
 
   if vim.fn.input("Revert current file? (y/n): "):lower() ~= "y" then
     return
@@ -251,15 +230,13 @@ M.revert_current = function()
   if revert_file(rel_path, has_snapshot and tostring(snapshot_path) or nil) then
     local file = Path:new(rel_path)
     if file:exists() then
-      vim.cmd('e!')       -- Reload the buffer if file still exists
+      vim.cmd('e!')
     else
-      vim.cmd('bdelete!') -- Close the buffer if file was deleted
+      vim.cmd('bdelete!')
     end
   end
-end
+end)
 
--- Function to reset the git project status cache
--- Should be called if the working directory changes
 M.reset_git_status = function()
   M.__is_git_project = nil
 end


### PR DESCRIPTION
If after submitting a prompt goose has made changes to our files, we can review the file changes (diff) and/or revert them.

default mappings:
```
      diff_changes = '<leader>gd',           -- Display a vertical split diff of changes since the last goose prompt
      revert_all = '<leader>gra',            -- Revert all file changes since the last goose prompt
      revert_this = '<leader>grt',           -- Revert current file changes since the last goose prompt
```

closes #39 