### PR TITLE
feat: set goose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ This plugin provides a bridge between neovim and the [goose](https://github.com/
 
 ## 📋 Requirements
 
-- Goose CLI installed and available (see [Setting up goose](#-setting-up-goose-cli) below)
+- Goose CLI installed and available (see [Setting up goose](#-setting-up-goose) below)
 
 ## 🚀 Installation
 
-Install the plugin with your favorite package manager. See the [Configuration](#-configuration) section below for customization options.
+Install the plugin with your favorite package manager. See the [Configuration](#️-configuration) section below for customization options.
 
 ### With lazy.nvim
 
@@ -71,6 +71,8 @@ require('goose').setup({
       close = '<leader>gq',                  -- Close UI windows
       toggle_fullscreen = '<leader>gf',      -- Toggle between normal and fullscreen mode
       select_session = '<leader>gs',         -- Select and load a goose session
+      goose_mode_chat = '<leader>gmc',       -- Set goose mode to `chat`. (Tool calling disabled. No editor context besides selections)
+      goose_mode_auto = '<leader>gma'        -- Set goose mode to `auto`. (Default mode with full agent capabilities)
 
       diff = {
         open = '<leader>gd',                 -- Opens a diff tab of a modified file since the last goose prompt
@@ -94,9 +96,11 @@ require('goose').setup({
   ui = {
     window_width = 0.35,                   -- Width as percentage of editor width
     input_height = 0.15,                   -- Input height as percentage of window height
-    fullscreen = false,                     -- Start in fullscreen mode (default: false)
+    fullscreen = false,                    -- Start in fullscreen mode (default: false)
     layout = "right",                      -- Options: "center" or "right"
-    floating_height = 0.8,                 -- Height as percentage of editor height for floating layout
+    floating_height = 0.8,                 -- Height as percentage of editor height for "center" layout
+    display_model = true,                  -- Display model name on top winbar
+    display_goose_mode = true              -- Display mode on top winbar: auto|chat
   }
 })
 ```

--- a/lua/goose/api.lua
+++ b/lua/goose/api.lua
@@ -1,4 +1,5 @@
 local core = require("goose.core")
+
 local ui = require("goose.ui.ui")
 local state = require("goose.state")
 local review = require("goose.review")
@@ -41,6 +42,25 @@ function M.toggle_focus()
   else
     ui.return_to_last_code_win()
   end
+end
+
+function M.change_mode(mode)
+  local info_mod = require("goose.info")
+  info_mod.set_config_value(info_mod.GOOSE_INFO.MODE, mode)
+
+  if state.windows then
+    require('goose.ui.topbar').render()
+  else
+    vim.notify('Goose mode changed to ' .. mode)
+  end
+end
+
+function M.set_chat_mode()
+  M.change_mode(require('goose.info').GOOSE_MODE.CHAT)
+end
+
+function M.set_auto_mode()
+  M.change_mode(require('goose.info').GOOSE_MODE.AUTO)
 end
 
 function M.stop()
@@ -191,6 +211,22 @@ M.commands = {
     desc = "Toggle between input and output panes",
     fn = function()
       M.toggle_pane()
+    end
+  },
+
+  chat_mode = {
+    name = "GooseModeChat",
+    desc = "Set goose mode to `chat`. (Tool calling disabled. No editor context besides selections)",
+    fn = function()
+      M.set_chat_mode()
+    end
+  },
+
+  auto_mode = {
+    name = "GooseModeAuto",
+    desc = "Set goose mode to `auto`. (Default mode with full agent capabilities)",
+    fn = function()
+      M.set_auto_mode()
     end
   },
 

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -1,6 +1,4 @@
 -- Default and user-provided settings for goose.nvim
---
-
 
 local M = {}
 
@@ -16,6 +14,8 @@ M.defaults = {
       close = '<leader>gq',
       toggle_fullscreen = '<leader>gf',
       select_session = '<leader>gs',
+      goose_mode_chat = '<leader>gmc',
+      goose_mode_auto = '<leader>gma',
 
       diff = {
         open = '<leader>gd',
@@ -42,6 +42,8 @@ M.defaults = {
     fullscreen = false,
     layout = "right",
     floating_height = 0.8,
+    display_model = true,
+    display_goose_mode = true
   }
 }
 

--- a/lua/goose/context.lua
+++ b/lua/goose/context.lua
@@ -136,9 +136,20 @@ function M.get_current_selection()
 end
 
 function M.format_message(prompt)
-  local delta_context = M.delta_context()
-  delta_context.prompt = prompt
-  return template.render_template(delta_context)
+  local info = require('goose.info')
+  local context = nil
+
+  if info.parse_goose_info().goose_mode == info.GOOSE_MODE.CHAT then
+    -- For chat mode only send selection context
+    context = {
+      selections = M.context.selections
+    }
+  else
+    context = M.delta_context()
+  end
+
+  context.prompt = prompt
+  return template.render_template(context)
 end
 
 function M.extract_from_message(text)

--- a/lua/goose/info.lua
+++ b/lua/goose/info.lua
@@ -1,4 +1,16 @@
 local M = {}
+local util = require('goose.util')
+
+M.GOOSE_INFO = {
+  MODEL = "GOOSE_MODEL",
+  MODE = "GOOSE_MODE",
+  CONFIG = "Config file"
+}
+
+M.GOOSE_MODE = {
+  CHAT = "chat",
+  AUTO = "auto"
+}
 
 -- Parse the output of `goose info -v` command
 function M.parse_goose_info()
@@ -12,12 +24,33 @@ function M.parse_goose_info()
   local output = handle:read("*a")
   handle:close()
 
-  local model = output:match("GOOSE_MODEL:%s*(.-)\n") or output:match("GOOSE_MODEL:%s*(.-)$")
+  local model = output:match(M.GOOSE_INFO.MODEL .. ":%s*(.-)\n") or output:match(M.GOOSE_INFO.MODEL .. ":%s*(.-)$")
   if model then
     result.goose_model = vim.trim(model)
   end
 
+  local mode = output:match(M.GOOSE_INFO.MODE .. ":%s*(.-)\n") or output:match(M.GOOSE_INFO.MODE .. ":%s*(.-)$")
+  if mode then
+    result.goose_mode = vim.trim(mode)
+  end
+
+  local config_file = output:match(M.GOOSE_INFO.CONFIG .. ":%s*(.-)\n") or
+      output:match(M.GOOSE_INFO.CONFIG .. ":%s*(.-)$")
+  if config_file then
+    result.config_file = vim.trim(config_file)
+  end
+
   return result
+end
+
+-- Set a value in the goose config file
+function M.set_config_value(key, value)
+  local info = M.parse_goose_info()
+  if not info.config_file then
+    return false, "Could not find config file path"
+  end
+
+  return util.set_yaml_value(info.config_file, key, value)
 end
 
 return M

--- a/lua/goose/keymap.lua
+++ b/lua/goose/keymap.lua
@@ -61,6 +61,10 @@ function M.setup(keymap)
   vim.keymap.set({ 'n', 'v' }, global.diff.revert_this, function()
     api.revert_this()
   end, { silent = false, desc = cmds.revert_this.desc })
+
+  vim.keymap.set('n', global.goose_mode_chat, function() api.set_chat_mode() end, { desc = cmds.chat_mode.desc })
+
+  vim.keymap.set('n', global.goose_mode_auto, function() api.set_auto_mode() end, { desc = cmds.auto_mode.desc })
 end
 
 return M

--- a/lua/goose/ui/topbar.lua
+++ b/lua/goose/ui/topbar.lua
@@ -6,15 +6,40 @@ local LABELS = {
   NEW_SESSION_TITLE = "New session",
 }
 
-local function format_model_name()
-  local model = require("goose.info").parse_goose_info().goose_model
-  return (model and (model:match("[^/]+$") or model) or "")
+local function format_model_info()
+  local info = require("goose.info").parse_goose_info()
+  local config = require("goose.config").get()
+  local parts = {}
+
+  if config.ui.display_model then
+    local model = info.goose_model and (info.goose_model:match("[^/]+$") or info.goose_model) or ""
+    if model ~= "" then
+      table.insert(parts, model)
+    end
+  end
+
+  if config.ui.display_goose_mode then
+    local mode = info.goose_mode
+    if mode then
+      table.insert(parts, "[" .. mode .. "]")
+    end
+  end
+
+  return table.concat(parts, " ")
 end
 
-local function create_winbar_text(description, model_name, win_width)
-  local available_width = win_width - 2
-  local padding = string.rep(" ", available_width - #description - #model_name)
-  return string.format(" %s%s%s ", description, padding, model_name)
+
+local function create_winbar_text(description, model_info, win_width)
+  local available_width = win_width - 2 -- 2 padding spaces
+
+  -- If total length exceeds available width, truncate description
+  if #description + 1 + #model_info > available_width then
+    local space_for_desc = available_width - #model_info - 4 -- -4 for "... "
+    description = description:sub(1, space_for_desc) .. "... "
+  end
+
+  local padding = string.rep(" ", available_width - #description - #model_info)
+  return string.format(" %s%s%s ", description, padding, model_info)
 end
 
 local function update_winbar_highlights(win_id)
@@ -55,7 +80,7 @@ function M.render()
   vim.schedule(function()
     vim.wo[win].winbar = create_winbar_text(
       get_session_desc(),
-      format_model_name(),
+      format_model_info(),
       vim.api.nvim_win_get_width(win)
     )
 

--- a/lua/goose/ui/ui.lua
+++ b/lua/goose/ui/ui.lua
@@ -158,6 +158,7 @@ function M.toggle_fullscreen()
   ui_config.fullscreen = not ui_config.fullscreen
 
   require("goose.ui.window_config").configure_window_dimentions(windows)
+  require('goose.ui.topbar').render()
 
   if not M.is_goose_focused() then
     vim.api.nvim_set_current_win(windows.output_win)

--- a/lua/goose/util.lua
+++ b/lua/goose/util.lua
@@ -219,4 +219,49 @@ function M.time_ago(dateTime)
   end
 end
 
+-- Simple YAML key/value setter
+-- Note: This is a basic implementation that assumes simple YAML structure
+-- It will either update an existing key or append a new key at the end
+function M.set_yaml_value(path, key, value)
+  if not path then
+    return false, "No file path provided"
+  end
+
+  -- Read the current content
+  local lines = {}
+  local key_pattern = "^%s*" .. vim.pesc(key) .. ":%s*"
+  local found = false
+
+  local file = io.open(path, "r")
+  if not file then
+    return false, "Could not open file"
+  end
+
+  for line in file:lines() do
+    if line:match(key_pattern) then
+      -- Update existing key
+      lines[#lines + 1] = string.format("%s: %s", key, value)
+      found = true
+    else
+      lines[#lines + 1] = line
+    end
+  end
+  file:close()
+
+  -- If key wasn't found, append it
+  if not found then
+    lines[#lines + 1] = string.format("%s: %s", key, value)
+  end
+
+  -- Write back to file
+  file = io.open(path, "w")
+  if not file then
+    return false, "Could not open file for writing"
+  end
+  file:write(table.concat(lines, "\n"))
+  file:close()
+
+  return true
+end
+
 return M


### PR DESCRIPTION
```
goose_mode_chat = '<leader>gmc',       -- Set goose mode to `chat`. (Tool calling disabled. Chat only. No file context)
goose_mode_auto = '<leader>gma'        -- Set goose mode to `auto` (Default mode with full agent capabilities)
```

make visibility of mode or model in top winbar configurable - enabled by default