### PR TITLE
feat: quick provider/model switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ require('goose').setup({
       toggle_fullscreen = '<leader>gf',      -- Toggle between normal and fullscreen mode
       select_session = '<leader>gs',         -- Select and load a goose session
       goose_mode_chat = '<leader>gmc',       -- Set goose mode to `chat`. (Tool calling disabled. No editor context besides selections)
-      goose_mode_auto = '<leader>gma'        -- Set goose mode to `auto`. (Default mode with full agent capabilities)
+      goose_mode_auto = '<leader>gma',       -- Set goose mode to `auto`. (Default mode with full agent capabilities)
+      configure_provider = '<leader>gp'      -- Quick provider and model switch from predefined list
 
       diff = {
         open = '<leader>gd',                 -- Opens a diff tab of a modified file since the last goose prompt
@@ -102,6 +103,20 @@ require('goose').setup({
     floating_height = 0.8,                 -- Height as percentage of editor height for "center" layout
     display_model = true,                  -- Display model name on top winbar
     display_goose_mode = true              -- Display mode on top winbar: auto|chat
+  },
+  providers = {
+    --[[
+    Define available providers and their models for quick model switching
+    anthropic|azure|bedrock|databricks|google|groq|ollama|openai|openrouter
+    Example:
+    openrouter = {
+      "anthropic/claude-3.5-sonnet",
+      "openai/gpt-4.1",
+    },
+    ollama = {
+      "cogito:14b"
+    }
+    --]]
   }
 })
 ```
@@ -114,16 +129,17 @@ The plugin provides the following actions that can be triggered via keymaps, com
 
 | Action | Default keymap | Command | API Function |
 |-------------|--------|---------|---------|
-|  Open goose. Close if opened | `<leader>gg` | `:Goose` | `require('goose.api').toggle()` |
+| Open goose. Close if opened | `<leader>gg` | `:Goose` | `require('goose.api').toggle()` |
 | Open input window (current session) | `<leader>gi` | `:GooseOpenInput` | `require('goose.api').open_input()` |
 | Open input window (new session) | `<leader>gI` | `:GooseOpenInputNewSession` | `require('goose.api').open_input_new_session()` |
 | Open output window | `<leader>go` | `:GooseOpenOutput` | `require('goose.api').open_output()` |
-|  Toggle focus goose / last window | `<leader>gt` | `:GooseToggleFocus` | `require('goose.api').toggle_focus()` |
+| Toggle focus goose / last window | `<leader>gt` | `:GooseToggleFocus` | `require('goose.api').toggle_focus()` |
 | Close UI windows | `<leader>gq` | `:GooseClose` | `require('goose.api').close()` |
 | Toggle fullscreen mode | `<leader>gf` | `:GooseToggleFullscreen` | `require('goose.api').toggle_fullscreen()` |
 | Select and load session | `<leader>gs` | `:GooseSelectSession` | `require('goose.api').select_session()` |
+| Configure provider and model | `<leader>gp` | `:GooseConfigureProvider` | `require('goose.api').configure_provider()` |
 | Stop goose while it is running | `<C-c>`  | `:GooseStop` | `require('goose.api').stop()` |
-| [Pick a file and add to context](#file-mentions) | `@` |- | -|
+| [Pick a file and add to context](#file-mentions) | `@` | - | - |
 | Run prompt (continue session) | - | `:GooseRun <prompt>` | `require('goose.api').run("prompt")` |
 | Run prompt (new session) | - | `:GooseRunNewSession <prompt>` | `require('goose.api').run_new_session("prompt")` |
 | Navigate to next message | `]]` | - | - |
@@ -137,6 +153,15 @@ The plugin provides the following actions that can be triggered via keymaps, com
 | Close diff view tab | `<leader>gc` | `:GooseDiffClose` | `require('goose.api').close_diff()` |
 | Revert all file changes | `<leader>gra` | `:GooseRevertAll` | `require('goose.api').revert_all()` |
 | Revert current file changes | `<leader>grt` | `:GooseRevertThis` | `require('goose.api').revert_this()` |
+
+### Switching between providers and models
+
+You can easily switch between different AI providers and models:
+
+1. Use the `<leader>gm` keybinding (or run `:GooseSelectModel`)
+2. Select your desired provider and model from the dropdown menu (e.g., "openrouter: anthropic/claude-3.7-sonnet")
+
+This feature allows you to quickly switch between models for different tasks without manually editing the goose configuration file.
 
 ## 📝 Context
 

--- a/README.md
+++ b/README.md
@@ -154,14 +154,6 @@ The plugin provides the following actions that can be triggered via keymaps, com
 | Revert all file changes | `<leader>gra` | `:GooseRevertAll` | `require('goose.api').revert_all()` |
 | Revert current file changes | `<leader>grt` | `:GooseRevertThis` | `require('goose.api').revert_this()` |
 
-### Switching between providers and models
-
-You can easily switch between different AI providers and models:
-
-1. Use the `<leader>gm` keybinding (or run `:GooseSelectModel`)
-2. Select your desired provider and model from the dropdown menu (e.g., "openrouter: anthropic/claude-3.7-sonnet")
-
-This feature allows you to quickly switch between models for different tasks without manually editing the goose configuration file.
 
 ## 📝 Context
 

--- a/lua/goose/api.lua
+++ b/lua/goose/api.lua
@@ -64,6 +64,10 @@ function M.set_auto_mode()
   M.change_mode(require('goose.info').GOOSE_MODE.AUTO)
 end
 
+function M.configure_provider()
+  core.configure_provider()
+end
+
 function M.stop()
   core.stop()
 end
@@ -242,6 +246,14 @@ M.commands = {
     desc = "Set goose mode to `auto`. (Default mode with full agent capabilities)",
     fn = function()
       M.set_auto_mode()
+    end
+  },
+
+  configure_provider = {
+    name = "GooseConfigureProvider",
+    desc = "Quick provider and model switch from predefined list",
+    fn = function()
+      M.configure_provider()
     end
   },
 

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -16,6 +16,7 @@ M.defaults = {
       select_session = '<leader>gs',
       goose_mode_chat = '<leader>gmc',
       goose_mode_auto = '<leader>gma',
+      configure_provider = '<leader>gp',
 
       diff = {
         open = '<leader>gd',
@@ -46,6 +47,20 @@ M.defaults = {
     floating_height = 0.8,
     display_model = true,
     display_goose_mode = true
+  },
+  providers = {
+    --[[
+    Define available providers and their models for quick model switching
+    anthropic|azure|bedrock|databricks|google|groq|ollama|openai|openrouter
+    Example:
+    openrouter = {
+      "anthropic/claude-3.5-sonnet",
+      "openai/gpt-4.1",
+    },
+    ollama = {
+      "cogito:14b"
+    }
+    --]]
   }
 }
 

--- a/lua/goose/core.lua
+++ b/lua/goose/core.lua
@@ -121,6 +121,22 @@ function M.add_file_to_context()
   end)
 end
 
+function M.configure_provider()
+  local info_mod = require("goose.info")
+  require("goose.provider").select(function(selection)
+    if not selection then return end
+
+    info_mod.set_config_value(info_mod.GOOSE_INFO.PROVIDER, selection.provider)
+    info_mod.set_config_value(info_mod.GOOSE_INFO.MODEL, selection.model)
+
+    vim.notify("Changed provider to " .. selection.display, vim.log.levels.INFO)
+
+    if state.windows then
+      require('goose.ui.topbar').render()
+    end
+  end)
+end
+
 function M.stop()
   if (state.goose_run_job) then job.stop(state.goose_run_job) end
   state.goose_run_job = nil

--- a/lua/goose/info.lua
+++ b/lua/goose/info.lua
@@ -3,6 +3,7 @@ local util = require('goose.util')
 
 M.GOOSE_INFO = {
   MODEL = "GOOSE_MODEL",
+  PROVIDER = "GOOSE_PROVIDER",
   MODE = "GOOSE_MODE",
   CONFIG = "Config file"
 }
@@ -27,6 +28,11 @@ function M.parse_goose_info()
   local model = output:match(M.GOOSE_INFO.MODEL .. ":%s*(.-)\n") or output:match(M.GOOSE_INFO.MODEL .. ":%s*(.-)$")
   if model then
     result.goose_model = vim.trim(model)
+  end
+
+  local provider = output:match(M.GOOSE_INFO.PROVIDER .. ":%s*(.-)\n") or output:match(M.GOOSE_INFO.PROVIDER .. ":%s*(.-)$")
+  if provider then
+    result.goose_provider = vim.trim(provider)
   end
 
   local mode = output:match(M.GOOSE_INFO.MODE .. ":%s*(.-)\n") or output:match(M.GOOSE_INFO.MODE .. ":%s*(.-)$")

--- a/lua/goose/keymap.lua
+++ b/lua/goose/keymap.lua
@@ -65,6 +65,9 @@ function M.setup(keymap)
   vim.keymap.set('n', global.goose_mode_chat, function() api.set_chat_mode() end, { desc = cmds.chat_mode.desc })
 
   vim.keymap.set('n', global.goose_mode_auto, function() api.set_auto_mode() end, { desc = cmds.auto_mode.desc })
+
+  vim.keymap.set('n', global.configure_provider, function() api.configure_provider() end,
+    { desc = cmds.configure_provider.desc })
 end
 
 return M

--- a/lua/goose/provider.lua
+++ b/lua/goose/provider.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+function M.select(cb)
+  local config = require("goose.config")
+
+  -- Create a flat list of all provider/model combinations
+  local model_options = {}
+
+  for provider, models in pairs(config.get("providers")) do
+    for _, model in ipairs(models) do
+      table.insert(model_options, {
+        provider = provider,
+        model = model,
+        display = provider .. ": " .. model
+      })
+    end
+  end
+
+  if #model_options == 0 then
+    vim.notify("No models configured in providers", vim.log.levels.ERROR)
+    return
+  end
+
+  vim.ui.select(model_options, {
+    prompt = "Select model:",
+    format_item = function(item)
+      return item.display
+    end
+  }, function(selection)
+    cb(selection)
+  end)
+end
+
+return M


### PR DESCRIPTION
Added config:

```lua
keymap = {
    global = {
        configure_provider = '<leader>gp'      -- Quick provider and model switch from predefined list
    }
}
providers = {
    --[[
    Define available providers and their models for quick model switching
    anthropic|azure|bedrock|databricks|google|groq|ollama|openai|openrouter
    Example:
    openrouter = {
      "anthropic/claude-3.5-sonnet",
      "openai/gpt-4.1",
    },
    ollama = {
      "cogito:14b"
    }
    --]]
}
```