### PR TITLE
feat: add a `prefered_picker` option to force a specific picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Install the plugin with your favorite package manager. See the [Configuration](#
 ```lua
 -- Default configuration with all available options
 require('goose').setup({
+  prefered_picker = nil,                     -- 'telescope', 'fzf', 'mini.pick', 'snacks', if nil, it will use the best available picker
   default_global_keymaps = true,             -- If false, disables all default global keymaps
   keymap = {
     global = {

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -4,6 +4,7 @@ local M = {}
 
 -- Default configuration
 M.defaults = {
+  prefered_picker = nil,
   default_global_keymaps = true,
   keymap = {
     global = {

--- a/lua/goose/ui/file_picker.lua
+++ b/lua/goose/ui/file_picker.lua
@@ -1,6 +1,13 @@
 local M = {}
 
 local function get_best_picker()
+  local config = require("goose.config")
+
+  local prefered_picker =  config.get('prefered_picker')
+  if prefered_picker and prefered_picker ~= "" then
+    return prefered_picker
+  end
+  
   if pcall(require, "telescope") then return "telescope" end
   if pcall(require, "fzf-lua") then return "fzf" end
   if pcall(require, "mini.pick") then return "mini.pick" end


### PR DESCRIPTION
When a user have multiple picker installed but want to use a specific one.

The use case of this is having the mini extension installed but not enabling mini.pick and having another picker like telescope or snacks.

This MR provides a way to short circuit `get_best_picker`  method and use the option instead. It will still tries to find the best one if no value is provided
