### PR TITLE
feat: decouple insert and normal mode for submit keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ require('goose').setup({
   default_global_keymaps = true,             -- If false, disables all default global keymaps
   keymap = {
     global = {
-      toggle = '<leader>gg',                 -- Open goose. Close if opened 
+      toggle = '<leader>gg',                 -- Open goose. Close if opened
       open_input = '<leader>gi',             -- Opens and focuses on input window on insert mode
       open_input_new_session = '<leader>gI', -- Opens and focuses on input window on insert mode. Creates a new session
-      open_output = '<leader>go',            -- Opens and focuses on output window 
+      open_output = '<leader>go',            -- Opens and focuses on output window
       toggle_focus = '<leader>gt',           -- Toggle focus between goose and last window
       close = '<leader>gq',                  -- Close UI windows
       toggle_fullscreen = '<leader>gf',      -- Toggle between normal and fullscreen mode
@@ -84,6 +84,7 @@ require('goose').setup({
     },
     window = {
       submit = '<cr>',                     -- Submit prompt
+      submit_insert = '<cr>',              -- Submit prompt
       close = '<esc>',                     -- Close UI windows
       stop = '<C-c>',                      -- Stop goose while it is running
       next_message = ']]',                 -- Navigate to next message in the conversation

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ require('goose').setup({
       diff_revert_this = '<leader>grt',      -- Revert current file changes since the last goose prompt
     },
     window = {
-      submit = '<cr>',                     -- Submit prompt
+      submit = '<cr>',                     -- Submit prompt (normal mode)
       submit_insert = '<cr>',              -- Submit prompt
       close = '<esc>',                     -- Close UI windows
       stop = '<C-c>',                      -- Stop goose while it is running

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require('goose').setup({
     },
     window = {
       submit = '<cr>',                     -- Submit prompt (normal mode)
-      submit_insert = '<cr>',              -- Submit prompt
+      submit_insert = '<cr>',              -- Submit prompt (insert mode)
       close = '<esc>',                     -- Close UI windows
       stop = '<C-c>',                      -- Stop goose while it is running
       next_message = ']]',                 -- Navigate to next message in the conversation

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -28,6 +28,7 @@ M.defaults = {
     },
     window = {
       submit = '<cr>',
+      submit_insert = '<cr>',
       close = '<esc>',
       stop = '<C-c>',
       next_message = ']]',

--- a/lua/goose/ui/window_config.lua
+++ b/lua/goose/ui/window_config.lua
@@ -221,7 +221,11 @@ function M.setup_keymaps(windows)
   local window_keymap = config.keymap.window
   local api = require('goose.api')
 
-  vim.keymap.set({ 'i', 'n' }, window_keymap.submit, function()
+  vim.keymap.set({  'n' }, window_keymap.submit, function()
+    handle_submit(windows)
+  end, { buffer = windows.input_buf, silent = false })
+
+  vim.keymap.set({  'i' }, window_keymap.submit_insert, function()
     handle_submit(windows)
   end, { buffer = windows.input_buf, silent = false })
 


### PR DESCRIPTION
This MR is decoupling the submit keymap from the insert mode one.

For compatibility I gave them both the same default value

The reason for this is that I usually want to add new lines in insert mode whan composing my prompt. with the current implementation It was sending the prompt immediately.