### PR TITLE
fix: escape new lines on tool calls

### DIFF
--- a/lua/goose/ui/session_formatter.lua
+++ b/lua/goose/ui/session_formatter.lua
@@ -90,6 +90,10 @@ end
 
 function M._format_context(lines, type, value)
   if not type or not value then return end
+
+  -- escape new lines
+  value = value:gsub("\n", "\\n")
+
   local formatted_action = ' **' .. type .. '** ` ' .. value .. ' `'
   table.insert(lines, formatted_action)
 end


### PR DESCRIPTION
if a tool call contained new lines, a fatal error was thrown when trying to read a session, this should fix it