### PR TITLE
feat: slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This plugin provides a bridge between neovim and the [goose](https://github.com/
 - [Configuration](#️-configuration)
 - [Usage](#-usage)
 - [Context](#-context)
+- [Completions](#-completions)
 - [Setting up goose](#-setting-up-goose)
 
 ## 📋 Requirements
@@ -177,6 +178,32 @@ The following editor context is automatically captured and included in your conv
 
 You can reference files in your project directly in your conversations with Goose. This is useful when you want to ask about or provide context about specific files. Type `@` in the input window to trigger the file picker. 
 Supported pickers include [`fzf-lua`](https://github.com/ibhagwan/fzf-lua), [`telescope`](https://github.com/nvim-telescope/telescope.nvim), [`mini.pick`](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md), [`snacks`](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
+
+## ⚡ Completions
+
+Completions allow you to reference different resource types quickly by auto completing their names. Currently supported completion types are:
+- [Slash Commands](#slash-commands)
+
+Completions are implemented as neovim native [`omnifunc`](https://neovim.io/doc/user/options.html#'omnifunc').
+goose.nvim automatically configures the following plugins to support these omnifunc completions:
+- **[blink.cmp](https://github.com/Saghen/blink.cmp)**
+
+<a id="slash-commands"></a>
+### Slash Commands
+
+Type `/` at the start to complete slash commands:
+
+- **Base commands:** `/compact`, `/clear`, `/prompts`, `/prompt`
+- **Custom commands:** Defined in `~/.config/goose/config.yaml` under `slash_commands`, each linked to a recipe
+
+Example configuration:
+```yaml
+slash_commands:
+  - command: design
+    recipe_path: /path/to/recipes/design.yaml
+  - command: review
+    recipe_path: /path/to/recipes/code-review.yaml
+``` 
 
 ## 🔧 Setting up goose 
 

--- a/lua/goose/completion.lua
+++ b/lua/goose/completion.lua
@@ -1,0 +1,104 @@
+local M = {}
+
+---@type table<string, fun(trigger: string): OmniFnCompleteItem[]>
+M.omni_sources = {
+  ['/'] = require('goose.slash_commands').get_completable,
+  -- ['#'] = function() return {} end, -- Future: skills
+  -- ['@'] = function() return {} end, -- Future: file mentions
+}
+
+_G.goose_omnifunc = function(findstart, base)
+  return require('goose.completion').complete(findstart, base)
+end
+
+function M.setup(bufnr)
+  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.goose_omnifunc')
+
+  M.setup_cmp_plugins()
+
+  vim.api.nvim_create_autocmd('CompleteDone', {
+    buffer = bufnr,
+    callback = function()
+      M.on_complete_done(vim.v.completed_item)
+    end,
+  })
+end
+
+function M.on_complete_done(item)
+  -- complete done trigger handler
+  return
+end
+
+function M.complete(findstart, base)
+  if findstart == 1 then
+    return M.find_completion_start()
+  else
+    return M.get_completions(base)
+  end
+end
+
+---Scans backwards from cursor to find completion start position for trigger characters.
+---@return number column 0-indexed start position, or -3 to cancel completion
+function M.find_completion_start()
+  local line = vim.api.nvim_get_current_line()
+  local col = vim.fn.col('.') - 1
+
+  if col == 0 then
+    return -3 -- Cancel completion
+  end
+
+  local start_col = col
+  while start_col > 0 do
+    local char = line:sub(start_col, start_col)
+    if M.omni_sources[char] then
+      -- Special handling for '/' - only at buffer start
+      if char == '/' then
+        local line_num = vim.fn.line('.')
+        if line_num == 1 and start_col == 1 then
+          return start_col - 1 -- Return 0-indexed column
+        else
+          return -3            -- Cancel - '/' not at buffer start
+        end
+      end
+
+      -- Other trigger chars: at line start or after whitespace
+      if start_col == 1 or line:sub(start_col - 1, start_col - 1):match('%s') then
+        return start_col - 1 -- Return 0-indexed column
+      else
+        return -3            -- Cancel - trigger char not after whitespace
+      end
+    elseif char:match('%s') then
+      break -- Stop at whitespace
+    end
+    start_col = start_col - 1
+  end
+
+  return -3 -- Cancel completion
+end
+
+---@return OmniFnCompleteItem[]
+function M.get_completions(base)
+  local trigger = base:sub(1, 1)
+  local source_fn = M.omni_sources[trigger]
+  if not source_fn then return {} end
+  return source_fn(trigger)
+end
+
+---In case other completion plugins are used, setup any necessary integration here.
+function M.setup_cmp_plugins()
+  -- Blink
+  local blink_enabled, blink_config = pcall(require, 'blink.cmp.config')
+  if blink_enabled then
+    blink_config.sources.per_filetype.GooseInput = { 'omni' }
+    blink_config.sources.providers.omni.override = {
+      get_trigger_characters = function()
+        if vim.bo.filetype == 'GooseInput' then
+          return vim.tbl_keys(M.omni_sources)
+        end
+        return {}
+      end
+    }
+  end
+end
+
+return M

--- a/lua/goose/context.lua
+++ b/lua/goose/context.lua
@@ -108,7 +108,7 @@ function M.delta_context()
   if not last_context then return context end
 
   -- no need to send file context again
-  if context.current_file and context.current_file.name == last_context and last_context.current_file.name then
+  if context.current_file and last_context.current_file and context.current_file.name == last_context.current_file.name then
     context.current_file = nil
   end
 
@@ -173,9 +173,12 @@ end
 function M.format_message(prompt)
   local info = require('goose.info')
   local context = nil
+  local is_slash_cmd = prompt:sub(1, 1) == '/'
 
   if info.mode() == info.MODE.CHAT then
     context = { selections = M.context.selections }
+  elseif is_slash_cmd then
+    context = {}
   else
     context = M.delta_context()
   end

--- a/lua/goose/core.lua
+++ b/lua/goose/core.lua
@@ -12,6 +12,11 @@ function M.select_session()
     return s.description ~= '' and s ~= nil
   end, all_sessions)
 
+  if vim.tbl_isempty(filtered_sessions) then
+    vim.notify("No sessions available.", vim.log.levels.WARN)
+    return
+  end
+
   ui.select_session(filtered_sessions, function(selected_session)
     if not selected_session then return end
     state.active_session = selected_session

--- a/lua/goose/info.lua
+++ b/lua/goose/info.lua
@@ -66,6 +66,11 @@ function M.is_extension_enabled(name)
   return exts[name] and exts[name].enabled == true
 end
 
+function M.slash_commands()
+  local cfg = load_config()
+  return cfg and cfg.data.slash_commands or {}
+end
+
 function M.set(key, value)
   local cfg = load_config()
   if not cfg then return false, "Could not load config" end

--- a/lua/goose/session.lua
+++ b/lua/goose/session.lua
@@ -9,7 +9,7 @@ function M.get_sessions()
   handle:close()
 
   local success, sessions = pcall(vim.fn.json_decode, result)
-  if not success or not sessions or next(sessions) == nil then return nil end
+  if not success or not sessions or next(sessions) == nil then return {} end
 
   return vim.tbl_map(function(session)
     local metadata = session.metadata or session

--- a/lua/goose/slash_commands.lua
+++ b/lua/goose/slash_commands.lua
@@ -1,0 +1,42 @@
+local M = {}
+
+local base_commands = { 'compact', 'clear', 'prompts', 'prompt' }
+
+local function get_commands_from_config()
+  local info = require('goose.info')
+  return info.slash_commands()
+end
+
+---@return SlashCommand[]
+function M.get_commands()
+  local configured_commands = get_commands_from_config()
+
+  local commands = {}
+
+  for _, cmd_entry in ipairs(configured_commands) do
+    if cmd_entry.command then
+      table.insert(commands, M.new(cmd_entry.command))
+    end
+  end
+
+  for _, base_cmd in ipairs(base_commands) do
+    table.insert(commands, M.new(base_cmd))
+  end
+
+  return commands
+end
+
+---@return SlashCommand
+function M.new(cmd)
+  return { cmd = cmd }
+end
+
+---@return OmniFnCompleteItem
+function M.get_completable()
+  local commands = M.get_commands()
+  return vim.tbl_map(function(command)
+    return { word = '/' .. command.cmd }
+  end, commands)
+end
+
+return M

--- a/lua/goose/types.lua
+++ b/lua/goose/types.lua
@@ -1,0 +1,6 @@
+---@class SlashCommand
+---@field cmd string
+
+---@class OmniFnCompleteItem
+---@field word string
+

--- a/lua/goose/ui/session_formatter.lua
+++ b/lua/goose/ui/session_formatter.lua
@@ -21,6 +21,10 @@ function M.format_session(session_name)
   local need_separator = false
 
   for i, message in ipairs(session.conversation) do
+    if message.metadata and message.metadata.userVisible == false then
+      goto continue
+    end
+
     local message_lines = M._format_message(message)
     if message_lines then
       if need_separator then

--- a/lua/goose/ui/window_config.lua
+++ b/lua/goose/ui/window_config.lua
@@ -27,7 +27,9 @@ function M.setup_options(windows)
   vim.api.nvim_buf_set_option(windows.input_buf, 'filetype', 'GooseInput')
   vim.api.nvim_buf_set_option(windows.input_buf, 'buftype', 'nofile')
   vim.api.nvim_buf_set_option(windows.input_buf, 'swapfile', false)
-  vim.b[windows.input_buf].completion = false
+
+  -- Setup completion
+  require('goose.completion').setup(windows.input_buf)
 
   -- Output window/buffer options
   vim.api.nvim_win_set_option(windows.output_win, 'winhighlight', highlight)
@@ -226,6 +228,7 @@ local function recover_input(windows)
 end
 
 function M.setup_after_actions(windows)
+  -- require('goose.completion').setup(windows.input_buf)
   recover_input(windows)
 end
 

--- a/lua/goose/ui/window_config.lua
+++ b/lua/goose/ui/window_config.lua
@@ -28,9 +28,6 @@ function M.setup_options(windows)
   vim.api.nvim_buf_set_option(windows.input_buf, 'buftype', 'nofile')
   vim.api.nvim_buf_set_option(windows.input_buf, 'swapfile', false)
 
-  -- Setup completion
-  require('goose.completion').setup(windows.input_buf)
-
   -- Output window/buffer options
   vim.api.nvim_win_set_option(windows.output_win, 'winhighlight', highlight)
   vim.api.nvim_win_set_option(windows.output_win, 'number', false)
@@ -228,7 +225,7 @@ local function recover_input(windows)
 end
 
 function M.setup_after_actions(windows)
-  -- require('goose.completion').setup(windows.input_buf)
+  require('goose.completion').setup(windows.input_buf)
   recover_input(windows)
 end
 


### PR DESCRIPTION
Adds support for slash commands with completions after typing `/`, listing the commands available

Completions use native [nvim omnifunc](https://neovim.io/doc/user/options.html#'omnifunc') with additional completion plugins support (for now just blink-cmp)

closes #48 