### PR TITLE
feat: autocomplete skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Supported pickers include [`fzf-lua`](https://github.com/ibhagwan/fzf-lua), [`te
 
 Completions allow you to reference different resource types quickly by auto completing their names. Currently supported completion types are:
 - [Slash Commands](#slash-commands)
+- [Skills](#skills)
 
 Completions are implemented as neovim native [`omnifunc`](https://neovim.io/doc/user/options.html#'omnifunc').
 goose.nvim automatically configures the following plugins to support these omnifunc completions:
@@ -194,7 +195,7 @@ goose.nvim automatically configures the following plugins to support these omnif
 Type `/` at the start to complete slash commands:
 
 - **Base commands:** `/compact`, `/clear`, `/prompts`, `/prompt`
-- **Custom commands:** Defined in `~/.config/goose/config.yaml` under `slash_commands`, each linked to a recipe
+- **[Custom commands](https://block.github.io/goose/docs/guides/recipes/session-recipes/#custom-recipe-commands):** Defined in `~/.config/goose/config.yaml` under `slash_commands`, each linked to a recipe.
 
 Example configuration:
 ```yaml
@@ -203,7 +204,16 @@ slash_commands:
     recipe_path: /path/to/recipes/design.yaml
   - command: review
     recipe_path: /path/to/recipes/code-review.yaml
-``` 
+```
+
+<a id="skills"></a>
+### Skills
+
+Type `#` to complete and mention skills in your conversations:
+
+Skills are reusable sets of instructions and resources that teach goose how to perform specific tasks. When you mention a skill using `#skill-name`, it gets added to the conversation context and Goose can utilize that skill.
+
+For more information about creating and using skills, see the [Goose Skills Documentation](https://block.github.io/goose/docs/guides/context-engineering/using-skills). 
 
 ## 🔧 Setting up goose 
 

--- a/lua/goose/api.lua
+++ b/lua/goose/api.lua
@@ -68,13 +68,9 @@ function M.configure_provider()
   core.configure_provider()
 end
 
-function M.mention_skill()
-  core.mention_skill()
-end
-
 function M.open_config()
   local info = require('goose.info')
-  
+
   local result = vim.system({ 'goose', 'info', '-v' }):wait()
   if result.code ~= 0 then
     vim.notify("Could not get config path", vim.log.levels.ERROR)
@@ -291,14 +287,6 @@ M.commands = {
     desc = "Quick provider and model switch from predefined list",
     fn = function()
       M.configure_provider()
-    end
-  },
-
-  mention_skill = {
-    name = "GooseMentionSkill",
-    desc = "Mention a skill from ~/.claude/skills",
-    fn = function()
-      M.mention_skill()
     end
   },
 

--- a/lua/goose/config.lua
+++ b/lua/goose/config.lua
@@ -36,7 +36,6 @@ M.defaults = {
       next_message = ']]',
       prev_message = '[[',
       mention_file = '@',
-      mention_skill = '#',
       toggle_pane = '<tab>',
       prev_prompt_history = '<up>',
       next_prompt_history = '<down>'

--- a/lua/goose/core.lua
+++ b/lua/goose/core.lua
@@ -149,21 +149,6 @@ function M.configure_provider()
   end)
 end
 
-function M.mention_skill()
-  if not require('goose.info').is_extension_enabled('skills') then
-    vim.notify("Skills extension is not enabled", vim.log.levels.WARN)
-    return
-  end
-
-  require('goose.ui.mention').mention(function(mention_cb)
-    require("goose.skills").select(function(skill)
-      if not skill then return end
-      mention_cb(skill.name)
-      context.add_skill(skill.name)
-    end)
-  end, keymap.window.mention_skill)
-end
-
 function M.stop()
   if (state.goose_run_job) then job.stop(state.goose_run_job) end
   state.goose_run_job = nil

--- a/lua/goose/skills.lua
+++ b/lua/goose/skills.lua
@@ -85,20 +85,28 @@ local function scan_skills()
   return all_skills
 end
 
-function M.select(cb)
+---@return OmniFnCompleteItem[]
+function M.get_completable()
   local skills = scan_skills()
+  return vim.tbl_map(function(skill)
+    return {
+      word = '#' .. skill.name,
+      menu = skill.description,
+      info = skill.description
+    }
+  end, skills)
+end
 
-  if #skills == 0 then
-    vim.notify("No skills found", vim.log.levels.WARN)
-    return
+---@param trigger string
+---@param item table
+function M.on_complete_done(trigger, item)
+  -- Extract skill name from word - handle cases like '_#skill-name' or '#skill-name'
+  local skill_name = item.word:match('#([%w_%-%.]+)')
+
+  if skill_name then
+    local context = require('goose.context')
+    context.add_skill(skill_name)
   end
-
-  vim.ui.select(skills, {
-    prompt = "Select skill:",
-    format_item = function(skill)
-      return skill.name
-    end
-  }, cb)
 end
 
 return M

--- a/lua/goose/types.lua
+++ b/lua/goose/types.lua
@@ -3,4 +3,6 @@
 
 ---@class OmniFnCompleteItem
 ---@field word string
+---@field menu string
+---@field info string
 

--- a/lua/goose/ui/window_config.lua
+++ b/lua/goose/ui/window_config.lua
@@ -88,6 +88,7 @@ function M.setup_autocmds(windows)
       local input_lines = vim.api.nvim_buf_get_lines(windows.input_buf, 0, -1, false)
       state.input_content = input_lines
       M.refresh_placeholder(windows, input_lines)
+      require('goose.ui.mention').highlight_all_mentions(windows.input_buf)
     end
   })
 
@@ -297,10 +298,6 @@ function M.setup_keymaps(windows)
 
   vim.keymap.set('i', window_keymap.mention_file, function()
     require('goose.core').add_file_to_context()
-  end, { buffer = windows.input_buf, silent = true })
-
-  vim.keymap.set('i', window_keymap.mention_skill, function()
-    require('goose.core').mention_skill()
   end, { buffer = windows.input_buf, silent = true })
 
   vim.keymap.set({ 'n', 'i' }, window_keymap.toggle_pane, function()


### PR DESCRIPTION
Type `#` to complete and mention skills in your conversations:

Skills are reusable sets of instructions and resources that teach goose how to perform specific tasks. When you mention a skill using `#skill-name`, it gets added to the conversation context and Goose can utilize that skill.

For more information about creating and using skills, see the [Goose Skills Documentation](https://block.github.io/goose/docs/guides/context-engineering/using-skills). 
